### PR TITLE
Increase the CMAKE minimal version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.0)
 project (emp-zk)
 set(NAME "emp-zk")
 


### PR DESCRIPTION
This is a very small change. Since `emp-tool` requires `2.8.12`, and `emp-ot` requires `3.0`, we can increase the CMake minimal version from `2.8.11` to `3.0`.

This is to suppress a warning when running `cmake .`:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```